### PR TITLE
Error when no supported VCS found

### DIFF
--- a/git-messenger.el
+++ b/git-messenger.el
@@ -321,12 +321,15 @@ and menus.")
 (defun git-messenger:find-vcs ()
   (let ((longest 0)
         result)
-    (dolist (vcs git-messenger:handled-backends result)
+    (dolist (vcs git-messenger:handled-backends)
       (let* ((dir (assoc-default vcs git-messenger:directory-of-vcs))
              (vcs-root (locate-dominating-file default-directory dir)))
         (when (and vcs-root (> (length vcs-root) longest))
           (setq longest (length vcs-root)
-                result vcs))))))
+                result vcs))))
+    (unless result
+      (error "Failed to find a supported version control repository"))
+    result))
 
 (defun git-messenger:svn-message (msg)
   (with-temp-buffer


### PR DESCRIPTION
Report an error when no supported VCS is found while invoking `git-messenger:popup-message`. Currently, when no git/svn/rg is found, the following error will emerge, which is not helpful at all.
```
git-messenger:popup-message: Wrong type argument: number-or-marker-p, nil
```